### PR TITLE
Close resource leak

### DIFF
--- a/java/src/main/java/org/whispersystems/signalservice/api/crypto/AttachmentCipherInputStream.java
+++ b/java/src/main/java/org/whispersystems/signalservice/api/crypto/AttachmentCipherInputStream.java
@@ -173,8 +173,7 @@ public class AttachmentCipherInputStream extends FileInputStream {
   }
 
   private void verifyMac(File file, Mac mac) throws FileNotFoundException, InvalidMacException {
-    try {
-      FileInputStream fin           = new FileInputStream(file);
+    try (FileInputStream fin = new FileInputStream(file)) {
       int             remainingData = Util.toIntExact(file.length()) - mac.getMacLength();
       byte[]          buffer        = new byte[4096];
 


### PR DESCRIPTION
verifyMac() creates its own FileInputStream, but doesn't close it.

@AsamK I would also merge this here, as the merging progress needs some time at upstream ;)