### PR TITLE
Use correct sticker pack key length of 32.

### DIFF
--- a/service/src/main/java/org/whispersystems/signalservice/api/SignalServiceMessageSender.java
+++ b/service/src/main/java/org/whispersystems/signalservice/api/SignalServiceMessageSender.java
@@ -436,8 +436,8 @@ public class SignalServiceMessageSender {
     if (manifest.getStickers().isEmpty()) {
       throw new AssertionError("Must have stickers!");
     }
-    if (packKey.length != 64) {
-      throw new AssertionError("Size of packKey must be 64!");
+    if (packKey.length != 32) {
+      throw new AssertionError("Size of packKey must be 32!");
     }
 
     int stickerCount = manifest.getStickers().size() + (manifest.getCover().isPresent() ? 1 : 0);


### PR DESCRIPTION
Pack keys should be 32 bytes which are then expanded to 64 via HKDF.

See Signal Desktop's upload process:
https://github.com/signalapp/Signal-Desktop/blob/87d6a55ce87a3f09e34da1dbc9e69f400ac7e32d/sticker-creator/preload.js#L93

Using a 64-byte key directly is technically valid, but it results in a URL that is much longer than necessary (since the pack key is hex-encoded and put in the URL as a query param).