### PR TITLE
WebSocketConnection respects URL Connection Specs

### DIFF
--- a/service/src/main/java/org/whispersystems/signalservice/api/SignalServiceMessageReceiver.java
+++ b/service/src/main/java/org/whispersystems/signalservice/api/SignalServiceMessageReceiver.java
@@ -259,8 +259,7 @@ public class SignalServiceMessageReceiver {
    * @return A SignalServiceMessagePipe for receiving Signal Service messages.
    */
   public SignalServiceMessagePipe createMessagePipe() {
-    WebSocketConnection webSocket = new WebSocketConnection(urls.getSignalServiceUrls()[0].getUrl(),
-                                                            urls.getSignalServiceUrls()[0].getTrustStore(),
+    WebSocketConnection webSocket = new WebSocketConnection(urls.getSignalServiceUrls()[0],
                                                             Optional.of(credentialsProvider), signalAgent, connectivityListener,
                                                             sleepTimer,
                                                             urls.getNetworkInterceptors(),
@@ -271,8 +270,7 @@ public class SignalServiceMessageReceiver {
   }
 
   public SignalServiceMessagePipe createUnidentifiedMessagePipe() {
-    WebSocketConnection webSocket = new WebSocketConnection(urls.getSignalServiceUrls()[0].getUrl(),
-                                                            urls.getSignalServiceUrls()[0].getTrustStore(),
+    WebSocketConnection webSocket = new WebSocketConnection(urls.getSignalServiceUrls()[0],
                                                             Optional.<CredentialsProvider>absent(), signalAgent, connectivityListener,
                                                             sleepTimer,
                                                             urls.getNetworkInterceptors(),

--- a/service/src/main/java/org/whispersystems/signalservice/internal/push/ProvisioningSocket.java
+++ b/service/src/main/java/org/whispersystems/signalservice/internal/push/ProvisioningSocket.java
@@ -28,7 +28,7 @@ public class ProvisioningSocket {
     // TODO should probably make this random, like in PushServiceSocket
     // TODO pass dns and proxy as well
     SignalServiceUrl[] serviceUrls = signalServiceConfiguration.getSignalServiceUrls();
-    connection = new WebSocketConnection(serviceUrls[0].getUrl(), serviceUrls[0].getTrustStore(), userAgent, null, timer, signalServiceConfiguration.getNetworkInterceptors(), Optional.absent(), Optional.absent());
+    connection = new WebSocketConnection(serviceUrls[0], userAgent, null, timer, signalServiceConfiguration.getNetworkInterceptors(), Optional.absent(), Optional.absent());
   }
 
   public ProvisioningUuid getProvisioningUuid() throws TimeoutException, IOException {

--- a/service/src/main/java/org/whispersystems/signalservice/internal/websocket/WebSocketConnection.java
+++ b/service/src/main/java/org/whispersystems/signalservice/internal/websocket/WebSocketConnection.java
@@ -13,6 +13,7 @@ import org.whispersystems.signalservice.api.util.Tls12SocketFactory;
 import org.whispersystems.signalservice.api.util.TlsProxySocketFactory;
 import org.whispersystems.signalservice.api.websocket.ConnectivityListener;
 import org.whispersystems.signalservice.internal.configuration.SignalProxy;
+import org.whispersystems.signalservice.internal.configuration.SignalServiceUrl;
 import org.whispersystems.signalservice.internal.util.BlacklistingTrustManager;
 import org.whispersystems.signalservice.internal.util.Util;
 import org.whispersystems.signalservice.internal.util.concurrent.ListenableFuture;
@@ -59,7 +60,7 @@ public class WebSocketConnection extends WebSocketListener {
   private final Map<Long, OutgoingRequest> outgoingRequests = new HashMap<>();
 
   private final String                        wsUri;
-  private final TrustStore                    trustStore;
+  private final SignalServiceUrl              signalServiceUrl;
   private final Optional<CredentialsProvider> credentialsProvider;
   private final String                        signalAgent;
   private final ConnectivityListener          listener;
@@ -74,8 +75,7 @@ public class WebSocketConnection extends WebSocketListener {
   private int                 attempts;
   private boolean             connected;
 
-  public WebSocketConnection(String httpUri,
-                             TrustStore trustStore,
+  public WebSocketConnection(SignalServiceUrl signalServiceUrl,
                              Optional<CredentialsProvider> credentialsProvider,
                              String signalAgent,
                              ConnectivityListener listener,
@@ -84,7 +84,7 @@ public class WebSocketConnection extends WebSocketListener {
                              Optional<Dns> dns,
                              Optional<SignalProxy> signalProxy)
   {
-    this.trustStore          = trustStore;
+    this.signalServiceUrl    = signalServiceUrl;
     this.credentialsProvider = credentialsProvider;
     this.signalAgent         = signalAgent;
     this.listener            = listener;
@@ -95,16 +95,16 @@ public class WebSocketConnection extends WebSocketListener {
     this.attempts            = 0;
     this.connected           = false;
 
-    String uri = httpUri.replace("https://", "wss://").replace("http://", "ws://");
+    String uri = signalServiceUrl.getUrl().replace("https://", "wss://").replace("http://", "ws://");
 
     if (credentialsProvider.isPresent()) this.wsUri = uri + "/v1/websocket/?login=%s&password=%s";
     else                                 this.wsUri = uri + "/v1/websocket/";
   }
   
-  public WebSocketConnection(String httpUri, TrustStore trustStore, String signalAgent, ConnectivityListener listener,
+  public WebSocketConnection(SignalServiceUrl signalServiceUrl, String signalAgent, ConnectivityListener listener,
                              SleepTimer timer, List<Interceptor> interceptors, Optional<Dns> dns,
                              Optional<SignalProxy> signalProxy) {
-    this.trustStore          = trustStore;
+    this.signalServiceUrl    = signalServiceUrl;
     this.credentialsProvider = Optional.absent();
     this.signalAgent         = signalAgent;
     this.listener            = listener;
@@ -114,7 +114,7 @@ public class WebSocketConnection extends WebSocketListener {
     this.signalProxy         = signalProxy;
     this.attempts            = 0;
     this.connected           = false;
-    this.wsUri               = httpUri.replace("https://", "wss://")
+    this.wsUri               = signalServiceUrl.getUrl().replace("https://", "wss://")
                                       .replace("http://", "ws://") + "/v1/websocket/provisioning/";
   }
 
@@ -133,11 +133,11 @@ public class WebSocketConnection extends WebSocketListener {
       } else {
         filledUri = wsUri;
       }
-      Pair<SSLSocketFactory, X509TrustManager> socketFactory = createTlsSocketFactory(trustStore);
+      Pair<SSLSocketFactory, X509TrustManager> socketFactory = createTlsSocketFactory(signalServiceUrl.getTrustStore());
 
       OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder()
                                                            .sslSocketFactory(new Tls12SocketFactory(socketFactory.first()), socketFactory.second())
-                                                           .connectionSpecs(Util.immutableList(ConnectionSpec.RESTRICTED_TLS))
+                                                           .connectionSpecs(signalServiceUrl.getConnectionSpecs().or(Util.immutableList(ConnectionSpec.RESTRICTED_TLS)))
                                                            .readTimeout(KEEPALIVE_TIMEOUT_SECONDS + 10, TimeUnit.SECONDS)
                                                            .dns(dns.or(Dns.SYSTEM))
                                                            .connectTimeout(KEEPALIVE_TIMEOUT_SECONDS + 10, TimeUnit.SECONDS);


### PR DESCRIPTION
Changes the WebSocketConnection to use the SignalUrl ConnectionSpecs, just the same as PushServiceSocket does already.

https://github.com/Turasa/libsignal-service-java/blob/8d34edc9f2d664e7524998f59d996bb30af33065/service/src/main/java/org/whispersystems/signalservice/internal/websocket/WebSocketConnection.java#L140

https://github.com/Turasa/libsignal-service-java/blob/8704a5ff73ee8338d48429dc920a4d8947a9b44f/service/src/main/java/org/whispersystems/signalservice/internal/push/PushServiceSocket.java#L1891

Some background...
I am testing signal-cli with cleartext enabled, for experimental / debugging purposes, and have configured the server URL with
the CLEARTEXT spec, however it does not propagate to the websocket connection.


