### PR TITLE
fix: parse targetAuthorAciBinary in createReaction for Android compatibility

### DIFF
--- a/service/src/main/java/org/whispersystems/signalservice/api/messages/SignalServiceContent.kt
+++ b/service/src/main/java/org/whispersystems/signalservice/api/messages/SignalServiceContent.kt
@@ -1520,10 +1520,17 @@ class SignalServiceContent {
 
     private fun createReaction(content: DataMessage): SignalServiceDataMessage.Reaction? {
       val reaction = content.reaction
-      if (reaction?.emoji == null || reaction.targetAuthorAci == null || reaction.targetSentTimestamp == null) {
+      if (reaction?.emoji == null || reaction.targetSentTimestamp == null) {
         return null
       }
-      val aci = ACI.parseOrNull(reaction.targetAuthorAci)
+      // Try binary ACI first (used by Android), then fall back to string ACI (used by Desktop)
+      val aci = if (reaction.targetAuthorAciBinary != null) {
+        ACI.parseOrNull(reaction.targetAuthorAciBinary)
+      } else if (reaction.targetAuthorAci != null) {
+        ACI.parseOrNull(reaction.targetAuthorAci)
+      } else {
+        null
+      }
       if (aci == null) {
         Log.w(TAG, "Cannot parse author UUID on reaction")
         return null


### PR DESCRIPTION
## Problem

`createReaction()` in `SignalServiceContent.kt` only checks `targetAuthorAci` (String) when parsing incoming reactions. Android clients send reactions with only `targetAuthorAciBinary` (Binary/ByteString) set, causing all reactions from Android to be silently dropped (`createReaction` returns `null`).

This was reported in AsamK/signal-cli#1931.

## Fix

Try `targetAuthorAciBinary` first, then fall back to `targetAuthorAci`. This mirrors the existing behavior in `createPollVote()` (line 1637) which already correctly uses `targetAuthorAciBinary`.

## Changes

- `SignalServiceContent.kt`: Modified `createReaction()` to parse `targetAuthorAciBinary` (Binary) first, with `targetAuthorAci` (String) as fallback
- Removed the `targetAuthorAci == null` check from the early-return guard, since the ACI can now come from either field

## Testing

Verified with a bytecode-patched signal-cli 0.13.24 that Android reactions are now correctly received.