### PR TITLE
Fix: handle null serverGuid to prevent NPE on incoming messages

### DIFF
--- a/lib/libsignal-service/src/main/java/org/whispersystems/signalservice/api/messages/SignalServiceMetadata.java
+++ b/lib/libsignal-service/src/main/java/org/whispersystems/signalservice/api/messages/SignalServiceMetadata.java
@@ -32,7 +32,7 @@ public final class SignalServiceMetadata {
     this.serverReceivedTimestamp  = serverReceivedTimestamp;
     this.serverDeliveredTimestamp = serverDeliveredTimestamp;
     this.needsReceipt             = needsReceipt;
-    this.serverGuid               = serverGuid;
+    this.serverGuid               = serverGuid != null ? serverGuid : "";
     this.groupId                  = groupId;
     this.destinationUuid          = destinationUuid != null ? destinationUuid : "";
   }


### PR DESCRIPTION
## Problem

Signal-cli receiving is broken by a `NullPointerException` in `getServerGuid()`: `"getServerGuid(...) must not be null"`. The Signal server has started sending envelopes without a serverGuid field, and `SignalServiceMetadata` passes the null value through directly — it crashes whenever an incoming message arrives.

This has been reproduced on signal-cli 0.14.3 and 0.14.4.1 affecting both daemon mode and direct CLI receive. A device re-link resolves it temporarily, but the crash returns within days.

## Root Cause

`SignalServiceMetadata.java` stores `serverGuid` directly without a null check:

```java
this.serverGuid = serverGuid;
```

When the server sends an envelope without a serverGuid, the field is null and any subsequent access (e.g. `getServerGuid().toString()` or comparison) throws NPE.

The same class already has the correct pattern for `destinationUuid`:

```java
this.destinationUuid = destinationUuid != null ? destinationUuid : "";
```

## Fix

Apply the identical null→"" default to `serverGuid`:

```java
this.serverGuid = serverGuid != null ? serverGuid : "";
```

## Verification

This fix has been live in production for over a week on signal-cli 0.14.4.1:
- **Before**: signal-cli daemon crashed on every incoming message (daily failures)
- **After**: zero NPE crashes, all inbound messages received normally

The patched jar was tested by applying the identical bytecode-level transformation to `signal-service-java-2.15.3_unofficial_147.jar`.

## Related

- signal-cli discussion: https://github.com/AsamK/signal-cli/discussions/2029